### PR TITLE
Fix ModelConfig missing expected_hash field

### DIFF
--- a/src/earsegmentationai/core/config.py
+++ b/src/earsegmentationai/core/config.py
@@ -28,6 +28,10 @@ class ModelConfig(BaseModel):
     activation: Optional[str] = Field(
         default="sigmoid", description="Output activation"
     )
+    expected_hash: Optional[str] = Field(
+        default=None,
+        description="Expected SHA256 hash of the model file for integrity check",
+    )
 
     @field_validator("architecture")
     @classmethod

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,6 +26,7 @@ class TestModelConfig:
         assert config.encoder_name == "resnet18"
         assert config.classes == 1
         assert config.activation == "sigmoid"
+        assert config.expected_hash is None
 
     def test_architecture_validation(self):
         """Test architecture validation."""
@@ -44,11 +45,13 @@ class TestModelConfig:
             architecture="DeepLabV3",
             encoder_name="resnet50",
             classes=2,
+            expected_hash="abc123",
         )
         assert config.name == "custom_model.pth"
         assert config.architecture == "DeepLabV3"
         assert config.encoder_name == "resnet50"
         assert config.classes == 2
+        assert config.expected_hash == "abc123"
 
 
 class TestProcessingConfig:


### PR DESCRIPTION
## Summary
- add `expected_hash` to `ModelConfig`
- test default and custom `expected_hash`

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684bbeaa6df0832d93767153ac58e56d