### PR TITLE
docs: expand base and model API documentation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,9 +6,9 @@ This directory contains the API documentation for Ear Segmentation AI.
 
 - [Image Processing API](image.md) - Process static images
 - [Video Processing API](video.md) - Process video streams
-- [Base Classes](base.md) - Common base classes and types
+- [Base Processing API](base.md) - Shared processor functionality and results
 - [Configuration API](config.md) - Configuration management
-- [Model API](model.md) - Model management and inference
+- [Model Management API](model.md) - Model download, caching and validation
 
 ## Quick Links
 

--- a/docs/api/base.md
+++ b/docs/api/base.md
@@ -1,0 +1,42 @@
+# Base Processing API
+
+## BaseProcessor
+
+The `BaseProcessor` provides shared functionality for all processing interfaces. It handles configuration loading, model initialization and common helper methods such as threshold and device management.
+
+### Responsibilities
+- manage configuration and override options
+- instantiate the `ModelManager`, pre-processing transforms and prediction utilities
+- provide reusable helpers (`set_device`, `set_threshold`, `get_info`, `warmup`, `clear_cache`)
+- define the abstract `process()` method implemented by subclasses
+
+### Usage
+```python
+from earsegmentationai.api.base import BaseProcessor
+
+class CustomProcessor(BaseProcessor):
+    def process(self, path: str):
+        image = cv2.imread(path)
+        mask = self.predictor.predict(image)
+        return ProcessingResult(image, mask)
+
+processor = CustomProcessor()
+result = processor.process("image.jpg")
+print(result.has_ear)
+```
+
+### Derived Classes
+- **ImageProcessor** – handles static image files and arrays
+- **VideoProcessor** – operates on video streams and frame sequences
+
+These classes implement the `process()` method to support their respective data sources.
+
+### Extension Points
+Subclasses can customise behaviour by:
+- overriding `process()` to accept new input types
+- replacing the transformation pipeline (`self.transform`)
+- injecting a custom `ModelManager` for advanced model control
+
+## Processing Results
+`ProcessingResult` encapsulates the original image, predicted mask and optional metadata. It offers convenience methods such as `has_ear`, `ear_area`, `ear_percentage`, `get_bounding_box`, and `get_center` to inspect predictions.
+

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -1,0 +1,41 @@
+# Model Management API
+
+## ModelManager
+The `ModelManager` handles model lifecycle tasks such as downloading weights, caching them locally and validating their integrity before use.
+
+### Download and Cache
+Models are stored under the path defined by configuration. `load_model()` checks the cache and downloads weights if missing or when `force_download=True`.
+
+```python
+from earsegmentationai.core.model import ModelManager
+
+manager = ModelManager()
+model = manager.model  # downloads and caches on first access
+
+# Force re-download
+manager.load_model(force_download=True)
+```
+
+### Validation
+Each download can be verified against an expected SHA256 hash. If the hash mismatches the file is rejected.
+
+```python
+model_path = manager.config.model_path
+manager._verify_model(model_path, manager.config.model.expected_hash)
+```
+
+### Device Management
+`ModelManager` keeps a single instance of the model and moves it between devices on demand.
+
+```python
+manager.set_device("cuda:0")
+info = manager.get_model_info()
+```
+
+### Clearing Cache
+GPU memory can be released using:
+
+```python
+manager.clear_cache()
+```
+


### PR DESCRIPTION
## Summary
- document BaseProcessor responsibilities, usage, and extension points
- add ModelManager guide covering download, cache, and validation
- update API README navigation to include new documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689779ccfd40832d827b1772e39c5bd4