### PR TITLE
feat: add Docker setup for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Multi-stage Dockerfile for Ear Segmentation AI
+
+# Base image
+FROM python:3.11-slim AS base
+
+# Builder stage: install dependencies and package
+FROM base AS builder
+
+# Install build tools
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install poetry to manage dependencies
+COPY pyproject.toml poetry.lock ./
+RUN pip install --no-cache-dir poetry && \
+    poetry export -f requirements.txt --output requirements.txt --without-hashes && \
+    pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Install the package itself
+COPY . .
+RUN pip install --no-cache-dir --prefix=/install .
+
+# Final runtime image
+FROM base AS runtime
+WORKDIR /app
+
+# Copy installed packages
+COPY --from=builder /install /usr/local
+
+# Copy example code
+COPY examples ./examples
+
+# Default command runs the basic example script
+CMD ["python", "examples/basic/basic_usage.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    command: python examples/basic/basic_usage.py

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -1,0 +1,37 @@
+# Docker Usage Guide
+
+This guide explains how to build and run the Ear Segmentation AI project using Docker.
+
+## Build the image
+
+```bash
+docker build -t ear-segmentation-ai .
+```
+
+This command uses the multi-stage `Dockerfile` in the repository root to install all dependencies and prepare the example application.
+
+## Run the container
+
+Run the example application directly with Docker:
+
+```bash
+docker run --rm ear-segmentation-ai
+```
+
+The container executes the `examples/basic/basic_usage.py` script by default.
+
+## Using docker-compose
+
+For local development you can use **docker-compose**:
+
+```bash
+docker compose up
+```
+
+This uses `docker-compose.yml` which mounts the project directory and exposes port `8000` (adjust as needed).
+
+Stop the services with `Ctrl+C` and remove containers with:
+
+```bash
+docker compose down
+```


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile that installs dependencies and runs example
- provide docker-compose.yml for local development
- document image build and container usage in docs/guides/docker.md

## Testing
- `make test` *(fails: ImportError: libGL.so.1: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_689779d106cc832daf96ffcf60d75151