### PR TITLE
Add unit tests for exceptions, logging, and visualization

### DIFF
--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,63 @@
+"""Unit tests for custom exceptions."""
+
+import pytest
+
+from earsegmentationai.utils.exceptions import (
+    ConfigurationError,
+    DeviceError,
+    EarSegmentationError,
+    InvalidInputError,
+    InvalidModelError,
+    ModelError,
+    ModelLoadError,
+    ModelNotFoundError,
+    ProcessingError,
+    ValidationError,
+    VideoError,
+)
+
+
+class TestExceptions:
+    """Test custom exception hierarchy and messages."""
+
+    @pytest.mark.parametrize(
+        "exc_cls,parent_cls",
+        [
+            (ModelError, EarSegmentationError),
+            (ModelNotFoundError, ModelError),
+            (ModelLoadError, ModelError),
+            (InvalidModelError, ModelError),
+            (ProcessingError, EarSegmentationError),
+            (InvalidInputError, ProcessingError),
+            (DeviceError, ProcessingError),
+            (VideoError, ProcessingError),
+            (ConfigurationError, EarSegmentationError),
+            (ValidationError, EarSegmentationError),
+        ],
+    )
+    def test_exception_inheritance(self, exc_cls, parent_cls):
+        """Each custom exception should inherit from its parent."""
+        assert issubclass(exc_cls, parent_cls)
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            EarSegmentationError,
+            ModelError,
+            ModelNotFoundError,
+            ModelLoadError,
+            InvalidModelError,
+            ProcessingError,
+            InvalidInputError,
+            DeviceError,
+            VideoError,
+            ConfigurationError,
+            ValidationError,
+        ],
+    )
+    def test_exception_message(self, exc_cls):
+        """Custom exceptions should preserve the provided message."""
+        message = "test error"
+        with pytest.raises(exc_cls) as exc_info:
+            raise exc_cls(message)
+        assert str(exc_info.value) == message

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,42 @@
+"""Unit tests for logging utilities."""
+
+import logging
+from unittest.mock import patch
+
+from earsegmentationai.utils.logging import get_logger, setup_logging
+
+
+class TestLogging:
+    """Test logging setup and retrieval."""
+
+    def test_setup_logging_level(self, caplog, test_config):
+        """setup_logging should respect the configured level."""
+        with patch(
+            "earsegmentationai.utils.logging.get_config", return_value=test_config
+        ):
+            logger = setup_logging(name="test_logger", level="INFO", use_rich=False)
+
+        caplog.set_level(logging.DEBUG, logger="test_logger")
+        logger.debug("debug message")
+        logger.info("info message")
+
+        messages = [r.message for r in caplog.records if r.name == "test_logger"]
+        assert "info message" in messages
+        assert "debug message" not in messages
+
+    def test_get_logger_level(self, caplog, test_config):
+        """get_logger should return logger with previously set level."""
+        with patch(
+            "earsegmentationai.utils.logging.get_config", return_value=test_config
+        ):
+            setup_logging(name="existing_logger", level="WARNING", use_rich=False)
+
+        logger = get_logger("existing_logger")
+        caplog.set_level(logging.DEBUG, logger="existing_logger")
+
+        logger.info("info message")
+        logger.error("error message")
+
+        messages = [r.message for r in caplog.records if r.name == "existing_logger"]
+        assert "error message" in messages
+        assert "info message" not in messages

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -1,0 +1,63 @@
+"""Unit tests for visualization utilities."""
+
+import numpy as np
+
+from earsegmentationai.postprocessing.visualization import (
+    MaskVisualizer,
+    create_grid_visualization,
+)
+
+
+class TestVisualization:
+    """Test visualization output shapes and types."""
+
+    def test_visualize_mask_output(self):
+        """visualize_mask should return an image with same shape and dtype."""
+        image = np.zeros((32, 32, 3), dtype=np.uint8)
+        mask = np.zeros((32, 32), dtype=np.uint8)
+        mask[8:16, 8:16] = 1
+
+        visualizer = MaskVisualizer(show_contours=False)
+        result = visualizer.visualize_mask(image, mask)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == image.shape
+        assert result.dtype == np.uint8
+
+    def test_visualize_probability_output(self):
+        """visualize_probability should match input image shape and dtype."""
+        image = np.zeros((32, 32, 3), dtype=np.uint8)
+        probability = np.random.rand(32, 32).astype(np.float32)
+
+        visualizer = MaskVisualizer(show_contours=False)
+        result = visualizer.visualize_probability(image, probability)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == image.shape
+        assert result.dtype == np.uint8
+
+    def test_visualize_comparison_output(self):
+        """visualize_comparison should produce grid with doubled dimensions."""
+        image = np.zeros((32, 32, 3), dtype=np.uint8)
+        mask = np.zeros((32, 32), dtype=np.uint8)
+        ground_truth = np.zeros((32, 32), dtype=np.uint8)
+
+        visualizer = MaskVisualizer(show_contours=False)
+        result = visualizer.visualize_comparison(image, mask, ground_truth)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (64, 64, 3)
+        assert result.dtype == np.uint8
+
+    def test_create_grid_visualization_output(self):
+        """create_grid_visualization should return grid image with correct shape."""
+        images = [np.zeros((32, 32, 3), dtype=np.uint8) for _ in range(4)]
+        masks = [np.zeros((32, 32), dtype=np.uint8) for _ in range(4)]
+
+        grid = create_grid_visualization(
+            images, masks, grid_shape=(2, 2), image_size=(32, 32)
+        )
+
+        assert isinstance(grid, np.ndarray)
+        assert grid.shape == (64, 64, 3)
+        assert grid.dtype == np.uint8


### PR DESCRIPTION
## Summary
- add tests validating custom exception inheritance and messages
- add logging tests to ensure setup and retrieval respect log levels
- add visualization tests verifying output shapes and types

## Testing
- `pytest tests/unit/test_exceptions.py tests/unit/test_logging.py tests/unit/test_visualization.py -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689779ce9878832d87dc3a606afd8357